### PR TITLE
feat: support css preset

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ ESLint config for @kazupon
   - `yml`
   - `toml`
   - `markdown`
+  - `css`
 - Support primitive eslint flat configuration
 - Support overrides for built-in configurations
   - `rules`
@@ -107,7 +108,8 @@ Add the following settings to your `.vscode/settings.json`:
     "json5",
     "markdown",
     "yaml",
-    "toml"
+    "toml",
+    "css"
   ],
   // Enable flat configuration
   "eslint.useFlatConfig": true
@@ -119,7 +121,7 @@ Add the following settings to your `.vscode/settings.json`:
 The following built-in preset configurations are supported:
 
 | Configuration | Powered by eslint plugin or package                                                                                                                                                                                                                                                                                                                                         | Need to install eslint plugin or package? |
-| ------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------- |
+| ------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------- | --- |
 | `javascript`  | [`@eslint/js`](https://www.npmjs.com/package/@eslint/js)                                                                                                                                                                                                                                                                                                                    | no (built-in)                             |
 | `comments`    | [`@eslint-community/eslint-plugin-eslint-comments`](https://www.npmjs.com/package/@eslint-community/eslint-plugin-eslint-comments)                                                                                                                                                                                                                                          | no (built-in)                             |
 | `typescript`  | [`typescript-eslint`](https://www.npmjs.com/package/typescript-eslint)                                                                                                                                                                                                                                                                                                      | yes                                       |
@@ -137,6 +139,7 @@ The following built-in preset configurations are supported:
 | `yml`         | [`eslint-plugin-yml`](https://www.npmjs.com/package/eslint-plugin-yml)                                                                                                                                                                                                                                                                                                      | yes                                       |
 | `toml`        | [`eslint-plugin-toml`](https://www.npmjs.com/package/eslint-plugin-toml)                                                                                                                                                                                                                                                                                                    | yes                                       |
 | `markdown`    | [`@eslint/markdown`](https://www.npmjs.com/package/@eslint/markdown)                                                                                                                                                                                                                                                                                                        | yes                                       |
+| `css`         | [`@eslint/css`](https://www.npmjs.com/package/@eslint/css)                                                                                                                                                                                                                                                                                                                  | yes                                       | k   |
 
 You can use `import` syntax:
 

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -1,5 +1,6 @@
 import {
   comments,
+  css,
   defineConfig,
   imports,
   javascript,
@@ -50,6 +51,9 @@ const config: ReturnType<typeof defineConfig> = defineConfig(
     prettier: true
   }),
   toml(),
+  css({
+    tolerant: true
+  }),
   vue({
     typescript: true,
     composable: true,

--- a/knip.config.ts
+++ b/knip.config.ts
@@ -6,6 +6,7 @@ const config: KnipConfig = {
     'lint-staged',
     '@types/eslint',
     '@eslint/markdown',
+    '@eslint/css',
     'eslint-config-prettier',
     'eslint-import-resolver-typescript',
     'eslint-plugin-import',

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "globals": "^16.0.0"
   },
   "peerDependencies": {
+    "@eslint/css": ">=0.4.0",
     "@eslint/markdown": ">=6.1.0",
     "@vitest/eslint-plugin": ">=1.0.0",
     "eslint": ">=8.56.0 || >=9.0.0",
@@ -103,6 +104,9 @@
     "typescript-eslint": ">=7.0.0"
   },
   "peerDependenciesMeta": {
+    "@eslint/css": {
+      "optional": true
+    },
     "@eslint/markdown": {
       "optional": true
     },
@@ -174,6 +178,7 @@
     }
   },
   "devDependencies": {
+    "@eslint/css": "^0.4.0",
     "@eslint/markdown": "^6.2.2",
     "@kazupon/prettier-config": "^0.1.1",
     "@types/eslint": "^9.6.1",
@@ -215,7 +220,14 @@
   "pnpm": {
     "onlyBuiltDependencies": [
       "esbuild"
-    ]
+    ],
+    "packageExtensions": {
+      "@eslint/css": {
+        "peerDependencies": {
+          "@types/css-tree": "2.3.10"
+        }
+      }
+    }
   },
   "prettier": "@kazupon/prettier-config",
   "lint-staged": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,8 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+packageExtensionsChecksum: sha256-/tpsUxzak38xPTtJAqMSdL/7jBwF7hgy7k264Dv0vPY=
+
 importers:
 
   .:
@@ -24,6 +26,9 @@ importers:
         specifier: ^16.0.0
         version: 16.0.0
     devDependencies:
+      '@eslint/css':
+        specifier: ^0.4.0
+        version: 0.4.0(@types/css-tree@2.3.10)
       '@eslint/markdown':
         specifier: ^6.2.2
         version: 6.2.2
@@ -335,6 +340,12 @@ packages:
   '@eslint/core@0.12.0':
     resolution: {integrity: sha512-cmrR6pytBuSMTaBweKoGMwu3EiHiEC+DoyupPmlZ0HxBJBtIxwe+j/E4XPIKNx+Q74c8lXKPwYawBf5glsTkHg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/css@0.4.0':
+    resolution: {integrity: sha512-aEvoIhIxa6nHvqTQxg56YgV8/9FO78ka1XnqkVnM07ZqJgeeILCNOHzwPs1z0N1vlj0Um2s4yMG8Ilau+D05Hg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      '@types/css-tree': 2.3.10
 
   '@eslint/eslintrc@3.3.0':
     resolution: {integrity: sha512-yaVPAiNAalnCZedKLdR21GOGILMLKPyqSLWaAjQFvYA2i/ciDi8ArYVr69Anohb6cH2Ukhqti4aFnYyPm8wdwQ==}
@@ -668,6 +679,9 @@ packages:
 
   '@tybys/wasm-util@0.9.0':
     resolution: {integrity: sha512-6+7nlbMVX/PVDCwaIQ8nTOPveOcFLSt8GcXdx8hD0bt39uWxYT88uXzqTd4fTvqta7oeUJqudepapKNt2DYJFw==}
+
+  '@types/css-tree@2.3.10':
+    resolution: {integrity: sha512-WcaBazJ84RxABvRttQjjFWgTcHvZR9jGr0Y3hccPkHjFyk/a3N8EuxjKr+QfrwjoM5b1yI1Uj1i7EzOAAwBwag==}
 
   '@types/debug@4.1.12':
     resolution: {integrity: sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==}
@@ -1063,6 +1077,10 @@ packages:
 
   css-tree@2.3.1:
     resolution: {integrity: sha512-6Fv1DV/TYw//QF5IzQdqsNDjx/wc8TrMBZsqjL9eW01tWb7R7k/mq+/VXfJCl7SoD5emsJop9cOByJZfs8hYIw==}
+    engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
+
+  css-tree@3.1.0:
+    resolution: {integrity: sha512-0eW44TGN5SQXU1mWSkKwFstI/22X2bG1nYzZTYMAWjylYURhse752YgbE4Cx46AC+bAvI+/dYTPRk1LqSUnu6w==}
     engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
 
   css@3.0.0:
@@ -2011,6 +2029,9 @@ packages:
 
   mdn-data@2.0.30:
     resolution: {integrity: sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA==}
+
+  mdn-data@2.12.2:
+    resolution: {integrity: sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==}
 
   merge-stream@2.0.0:
     resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
@@ -3225,6 +3246,13 @@ snapshots:
     dependencies:
       '@types/json-schema': 7.0.15
 
+  '@eslint/css@0.4.0(@types/css-tree@2.3.10)':
+    dependencies:
+      '@eslint/core': 0.10.0
+      '@eslint/plugin-kit': 0.2.7
+      '@types/css-tree': 2.3.10
+      css-tree: 3.1.0
+
   '@eslint/eslintrc@3.3.0':
     dependencies:
       ajv: 6.12.6
@@ -3484,6 +3512,8 @@ snapshots:
     dependencies:
       tslib: 2.8.1
     optional: true
+
+  '@types/css-tree@2.3.10': {}
 
   '@types/debug@4.1.12':
     dependencies:
@@ -3933,6 +3963,11 @@ snapshots:
   css-tree@2.3.1:
     dependencies:
       mdn-data: 2.0.30
+      source-map-js: 1.2.1
+
+  css-tree@3.1.0:
+    dependencies:
+      mdn-data: 2.12.2
       source-map-js: 1.2.1
 
   css@3.0.0:
@@ -5183,6 +5218,8 @@ snapshots:
       '@types/mdast': 4.0.4
 
   mdn-data@2.0.30: {}
+
+  mdn-data@2.12.2: {}
 
   merge-stream@2.0.0: {}
 

--- a/scripts/typegen.ts
+++ b/scripts/typegen.ts
@@ -41,7 +41,7 @@ function javascript(): Promise<PresetModule> {
 }
 
 /**
- * @returns {Promise<PresetModule>} javascript preset module
+ * @returns {Promise<PresetModule>} markdown preset module
  */
 function markdown(): Promise<PresetModule> {
   return {
@@ -51,6 +51,26 @@ function markdown(): Promise<PresetModule> {
       const configs = {
         plugins: {
           markdown: {
+            rules
+          }
+        }
+      }
+      return [configs]
+    }
+  }
+}
+
+/**
+ * @returns {Promise<PresetModule>} css preset module
+ */
+function css(): Promise<PresetModule> {
+  return {
+    // @ts-expect-error -- FIXME
+    css: async (): Promise<Linter.Config[]> => {
+      const { rules } = await interopDefault(await import('@eslint/css'))
+      const configs = {
+        plugins: {
+          css: {
             rules
           }
         }
@@ -87,6 +107,9 @@ async function resolvePresetModule(preset: string): Promise<PresetModule> {
     }
     case 'markdown': {
       return await markdown()
+    }
+    case 'css': {
+      return await css()
     }
     case 'react': {
       return await react()

--- a/src/configs/css.ts
+++ b/src/configs/css.ts
@@ -39,7 +39,7 @@ export async function css(
 ): Promise<Linter.Config[]> {
   const { rules: overrideRules = {} } = options
   const tolerant = !!options.tolerant
-  const customeSyntax = !!options.customSyntax
+  const customSyntax = !!options.customSyntax
 
   // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
   const css =
@@ -60,14 +60,14 @@ export async function css(
     }
   }
 
-  if (customeSyntax) {
+  if (customSyntax) {
     core.languageOptions = core.languageOptions || {}
-    if (typeof customeSyntax === 'string' && customeSyntax === 'tailwind') {
+    if (typeof customSyntax === 'string' && customSyntax === 'tailwind') {
       const { tailwindSyntax } =
         await loadPlugin<typeof import('@eslint/css/syntax')>('@eslint/css/syntax')
       core.languageOptions.customSyntax = tailwindSyntax
-    } else if (isObject(customeSyntax)) {
-      core.languageOptions.customSyntax = customeSyntax
+    } else if (isObject(customSyntax)) {
+      core.languageOptions.customSyntax = customSyntax
     }
   }
 

--- a/src/configs/index.ts
+++ b/src/configs/index.ts
@@ -1,4 +1,5 @@
 export * from './comments.ts'
+export * from './css.ts'
 export * from './imports.ts'
 export * from './javascript.ts'
 export * from './jsdoc.ts'

--- a/src/globs.ts
+++ b/src/globs.ts
@@ -16,6 +16,8 @@ export const GLOB_SVELTE = '**/*.svelte'
 
 export const GLOB_MARKDOWN = '**/*.md'
 
+export const GLOB_CSS = '**/*.css'
+
 const GLOB_SRC_EXT = '?([cm])[jt]s?(x)'
 
 export const GLOB_TESTS: string[] = [

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -2,6 +2,7 @@ export * from './overrides.ts'
 
 // for presets
 export * from './gens/comments.ts'
+export * from './gens/css.ts'
 export * from './gens/imports.ts'
 export * from './gens/javascript.ts'
 export * from './gens/jsdoc.ts'


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/kazupon/eslint-config/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

I've just supported css preset with `@eslint/css`
https://github.com/eslint/css

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

When I installed `@eslint/css` in this package, I met the issue in the following:
https://github.com/eslint/css/issues/56

The cause of this error seems to be that pnpm cannot correctly interpret the `file:` protocol.

I've work-arounded with following:

```json
  "pnpm": {
    "packageExtensions": {
      "@eslint/css": {
        "peerDependencies": {
          "@types/css-tree": "2.3.10"
        }
      }
    }
  },
```

The `dependencies` for `@eslint/css` have been overwritten with `“@types/css-tree”: “2.3.10”`. There are no problems with eslint-config, but if you are using it with a normal eslint.config.ts, there is a possibility of a type error occurring in the `languageOptions` settings.

`@eslint/css` will soon be forking `@types/css-tree` to resolve this issue, so the workaround using `pnpm.espackageExtensions` will no longer be necessary.

### Linked Issues

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
